### PR TITLE
fix: doubled types check, excluded unneccssary files from ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rimraf dist && tsc --emitDeclarationOnly && rollup --config",
+    "build": "rimraf dist && rollup --config",
     "tsc": "tsc",
     "test": "jest",
     "storybook": "start-storybook -p 6006",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "src/**/*.stories.tsx",
+    "src/**/*.test.tsx",
+    "src/test-setup.tsx"
   ],
   "compilerOptions": {
     "target": "es5",


### PR DESCRIPTION
fixes #3 doubled type check and excludes unnecessary files from TypeScript.